### PR TITLE
Fix cyrillic encoding in HTTP client

### DIFF
--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -79,7 +79,7 @@ class HTTPEasyVKClient {
         headers: self.headersRequest,
         agent: self._vk.agent
       }).then(async (res) => {
-        res = await res.text()
+        res = await res.textConverted()
 
         self._vk.debug(Debugger.EVENT_RESPONSE_TYPE, {
           body: res,


### PR DESCRIPTION
Этот мельчайший фикс исправляет кириллицу в HTTP клиенте (utf8: true не спасал).